### PR TITLE
Include necessary headers

### DIFF
--- a/src/BCRext/BCRext.cpp
+++ b/src/BCRext/BCRext.cpp
@@ -34,6 +34,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
+#include <fcntl.h>
 #include <fstream>
 #include <iostream>
 #include <sstream>

--- a/src/libzoo/util/TemporaryFilesManager.hh
+++ b/src/libzoo/util/TemporaryFilesManager.hh
@@ -21,6 +21,7 @@
 #include <cstdio>
 #include <inttypes.h>
 #include <memory>
+#include <stdlib.h>
 #include <string>
 #include <vector>
 

--- a/src/shared/SequenceExtractor.hh
+++ b/src/shared/SequenceExtractor.hh
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <fstream>
 #include <sstream>
+#include <vector>
 
 using namespace std;
 


### PR DESCRIPTION
I found it necessary to include the following three headers:
- `fcntl.h` for `O_RDONLY`
- `stdlib.h` for `malloc` and `free`
- `vector` for `std::vector`
