### PR TITLE
Release 0 10 0

### DIFF
--- a/src/BCR/BuildBCR.cpp
+++ b/src/BCR/BuildBCR.cpp
@@ -2117,7 +2117,7 @@ void BCRexternalBWT::storeEntirePairSA( const char *fn )
     LetterNumber numcharWrite, numcharRead;
     ElementType *buffer = new ElementType[SIZEBUFFER];
 
-    TmpFilename fnSA( fn, ".pairSA" );
+    Filename fnSA( fn, ".pairSA" );
 
     FILE *OutFileSA = fopen( fnSA, "wb" );
     if ( OutFileSA == NULL )
@@ -2247,8 +2247,8 @@ void BCRexternalBWT::storeEntireSAfromPairSA( const char *fn )
         }
         fclose(InFileLen);
     */
-    TmpFilename fnSA    ( fn, ".sa" );
-    TmpFilename fnPairSA( fn, ".pairSA" );
+    Filename fnSA    ( fn, ".sa" );
+    Filename fnPairSA( fn, ".pairSA" );
 
     FILE *InFilePairSA = fopen( fnPairSA, "rb" );
     if ( InFilePairSA == NULL )

--- a/src/BCR/Sorting.hh
+++ b/src/BCR/Sorting.hh
@@ -20,6 +20,7 @@
 
 #include "Alphabet.hh"
 #include "Types.hh"
+#include "Tools.hh"
 
 #include <vector>
 


### PR DESCRIPTION
These commits address two issues:
- the SA files were saved into the temporary directory, which prevented its deletion at the end of the execution;
- the LCP files were all 0s, since file `Tools.hh` was not correctly included and, thus, the pre-processor symbol BUILD_LCP was not defined in file `Sorting.hh`.
